### PR TITLE
perf: reduce thread contention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aaa7bd5fb665c6864b5f963dd9097905c54125909c7aa94c9e18507cdbe6c53"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf124c720b7686e3c2663cf54062ab0f68a88af2fb6a030e87e30bf721fcb38"
+dependencies = [
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "ctor"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.123.0"
+version = "0.126.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a1a1f98b03cde9638ae3662e60bbdff52e24db096dfbde8606fae024566bc04"
+checksum = "600b0066549fdd29c78c8106509cd1d24bacc56ef266397bb347cafb8367f6b5"
 dependencies = [
  "anyhow",
  "deno_ops",
@@ -137,9 +157,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.1.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83e5c17f5638c4a7778e5156b66188264922d59788f84489e9886f51793b973d"
+checksum = "8b1bf0375299ba35cef71c7530bddb6d67e8e7276226c6abc98a6986e01ddb1e"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -155,12 +175,13 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
 name = "dprint-core"
-version = "0.52.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8e428fa749f5ecc645fbeaed21795b6adb5d34590c33c53642e8c22577b48"
+checksum = "3fd76b7077b6ae550f8b4b72ee619548e22c579679fa7b0362261297b9fbd42a"
 dependencies = [
  "anyhow",
  "bumpalo",
+ "crossbeam-channel",
  "indexmap",
  "libc",
  "parking_lot 0.12.0",
@@ -336,15 +357,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
 
 [[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -433,29 +445,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "mio"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "wasi",
- "winapi",
-]
-
-[[package]]
-name = "miow"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "ntapi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,20 +454,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "output_vt100"
@@ -700,22 +679,13 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.34.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0828684228b81bf3faef9b3804b8bc9da88a7eb34c7c1eee67c5012925f879"
+checksum = "c83878134590f4d50ceb03f257dbd01646ffe675e8022bcd980365c3f20028d5"
 dependencies = [
  "serde",
  "serde_bytes",
  "v8",
-]
-
-[[package]]
-name = "signal-hook-registry"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -735,16 +705,6 @@ name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
-
-[[package]]
-name = "socket2"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
-dependencies = [
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "syn"
@@ -822,18 +782,8 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
 dependencies = [
- "bytes",
- "libc",
- "memchr",
- "mio",
- "num_cpus",
- "once_cell",
- "parking_lot 0.12.0",
  "pin-project-lite",
- "signal-hook-registry",
- "socket2",
  "tokio-macros",
- "winapi",
 ]
 
 [[package]]
@@ -922,12 +872,6 @@ dependencies = [
  "libc",
  "which",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "which"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,18 +5,18 @@ edition = "2021"
 
 [dependencies]
 async-channel = "1.6.1"
-dprint-core = { version = "0.52.1", features = ["process"] }
-deno_core = "0.123.0"
+dprint-core = { version = "0.53.0", features = ["process"] }
+deno_core = "0.126.0"
 once_cell = "1.9.0"
 serde = { version = "1.0.117", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 sysinfo = { version = "0.23.5", default-features = false }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["macros", "rt", "time"] }
 tokio-util = { version = "0.7.0" }
 zstd = "0.9.2"
 
 [build-dependencies]
-deno_core = "0.123.0"
+deno_core = "0.126.0"
 zstd = "0.9.2"
 
 [dev-dependencies]

--- a/build.rs
+++ b/build.rs
@@ -7,7 +7,6 @@ use std::path::PathBuf;
 
 use deno_core::serde_v8;
 use deno_core::v8;
-use deno_core::Extension;
 use deno_core::JsRuntime;
 use deno_core::RuntimeOptions;
 
@@ -65,9 +64,10 @@ fn main() {
 }
 
 fn get_runtime(startup_code_path: &Path, will_snapshot: bool) -> JsRuntime {
+  let platform = v8::new_default_platform(1, false).make_shared();
   let mut js_runtime = JsRuntime::new(RuntimeOptions {
     will_snapshot,
-    extensions: vec![Extension::builder().build()],
+    v8_platform: Some(platform),
     ..Default::default()
   });
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -43,6 +43,7 @@ impl Channel {
 
   pub async fn format(&self, request: FormatRequest<serde_json::Value>) -> FormatResult {
     let (send, recv) = oneshot::channel::<FormatResult>();
+    let mut should_inc_pending_runtimes = false;
     {
       let mut stats = self.stats.lock();
       if stats.pending_runtimes == 0 && (stats.total_runtimes == 0 || has_memory_available()) {
@@ -50,14 +51,18 @@ impl Channel {
         stats.pending_runtimes += 1;
         drop(stats);
         create_js_runtime(self.stats.clone(), self.receiver.clone());
-      } else {
+      } else if stats.pending_runtimes > 0 {
         stats.pending_runtimes -= 1;
+        should_inc_pending_runtimes = true;
       }
     }
+
     self.sender.send((request, send)).await?;
 
     let result = recv.await?;
-    self.stats.lock().pending_runtimes += 1;
+    if should_inc_pending_runtimes {
+      self.stats.lock().pending_runtimes += 1;
+    }
     result
   }
 }
@@ -70,32 +75,37 @@ fn has_memory_available() -> bool {
 }
 
 fn create_js_runtime(stats: Arc<Mutex<Stats>>, receiver: async_channel::Receiver<Request>) {
-  std::thread::spawn(|| {
+  std::thread::spawn(move || {
     let tokio_runtime = create_tokio_runtime();
     tokio_runtime.block_on(async move {
       let mut formatter = Formatter::new();
-      stats.lock().pending_runtimes += 1;
       loop {
         tokio::select! {
-          // automatically shut down after a certain amount of time
+          // automatically shut down after a certain amount of time to save memory
+          // in an editor scenario
           _ = tokio::time::sleep(Duration::from_secs(30)) => {
-            // only shut down if we're not the last one
+            // only shut down if we're not the last pending runtime
             let mut stats = stats.lock();
-            if stats.total_runtimes > 1 {
+            if stats.total_runtimes > 1 && stats.pending_runtimes > 1 {
               stats.total_runtimes -= 1;
+              stats.pending_runtimes -= 1;
               return;
             }
           }
           request = receiver.recv() => {
-            // todo: implement cancellation
+            // todo: possible to implement cancellation?
             let (request, response) = match request {
               Ok(result) => result,
               Err(_) => {
                 // receiver dropped, so exit
                 return;
-              },
+              }
             };
-            let result = formatter.format_text(&request.file_path.to_string_lossy(), request.file_text, &request.config);
+            let result = formatter.format_text(
+              &request.file_path.to_string_lossy(),
+              request.file_text,
+              &request.config,
+            );
             let _ = response.send(result);
           }
         }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -6,7 +6,6 @@ use deno_core::serde_json;
 use dprint_core::plugins::FormatRequest;
 use dprint_core::plugins::FormatResult;
 use tokio::sync::oneshot;
-use tokio_util::sync::CancellationToken;
 
 use crate::formatter::Formatter;
 use crate::utils::create_tokio_runtime;
@@ -27,7 +26,6 @@ pub struct Channel {
   stats: Arc<Mutex<Stats>>,
   sender: async_channel::Sender<Request>,
   receiver: async_channel::Receiver<Request>,
-  dispose_token: Arc<CancellationToken>,
 }
 
 impl Channel {
@@ -40,12 +38,7 @@ impl Channel {
       })),
       sender,
       receiver,
-      dispose_token: Default::default(),
     }
-  }
-
-  pub fn dispose(&self) {
-    self.dispose_token.cancel()
   }
 
   pub async fn format(&self, request: FormatRequest<serde_json::Value>) -> FormatResult {
@@ -54,28 +47,18 @@ impl Channel {
       let mut stats = self.stats.lock();
       if stats.pending_runtimes == 0 && (stats.total_runtimes == 0 || has_memory_available()) {
         stats.total_runtimes += 1;
-        create_js_runtime(self.clone());
+        stats.pending_runtimes += 1;
+        drop(stats);
+        create_js_runtime(self.stats.clone(), self.receiver.clone());
+      } else {
+        stats.pending_runtimes -= 1;
       }
     }
     self.sender.send((request, send)).await?;
 
-    recv.await?
-  }
-
-  /// Attempts to decrement the runtime count.
-  ///
-  /// Returns false if the runtime should stay alive
-  /// because it's the last one. This is done to prevent
-  /// a `send` occurring at the exact moment that a runtime
-  /// exits and so nothing will be around to receive a message.
-  fn try_decrement_runtime_count(&self) -> bool {
-    let mut stats = self.stats.lock();
-    if stats.total_runtimes == 1 {
-      false
-    } else {
-      stats.total_runtimes -= 1;
-      true
-    }
+    let result = recv.await?;
+    self.stats.lock().pending_runtimes += 1;
+    result
   }
 }
 
@@ -86,31 +69,33 @@ fn has_memory_available() -> bool {
   available_memory > 500_000
 }
 
-fn create_js_runtime(channel: Channel) {
+fn create_js_runtime(stats: Arc<Mutex<Stats>>, receiver: async_channel::Receiver<Request>) {
   std::thread::spawn(|| {
     let tokio_runtime = create_tokio_runtime();
     tokio_runtime.block_on(async move {
       let mut formatter = Formatter::new();
-      channel.stats.lock().pending_runtimes += 1;
+      stats.lock().pending_runtimes += 1;
       loop {
         tokio::select! {
-          // exit when dispose
-          _ = channel.dispose_token.cancelled() => {
-            return;
-          }
           // automatically shut down after a certain amount of time
           _ = tokio::time::sleep(Duration::from_secs(30)) => {
             // only shut down if we're not the last one
-            if channel.try_decrement_runtime_count() {
+            let mut stats = stats.lock();
+            if stats.total_runtimes > 1 {
+              stats.total_runtimes -= 1;
               return;
             }
           }
-          request = channel.receiver.recv() => {
+          request = receiver.recv() => {
             // todo: implement cancellation
-            channel.stats.lock().pending_runtimes -= 1;
-            let (request, response) = request.unwrap();
+            let (request, response) = match request {
+              Ok(result) => result,
+              Err(_) => {
+                // receiver dropped, so exit
+                return;
+              },
+            };
             let result = formatter.format_text(&request.file_path.to_string_lossy(), request.file_text, &request.config);
-            channel.stats.lock().pending_runtimes += 1; // set this before sending the response back
             let _ = response.send(result);
           }
         }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -26,12 +26,6 @@ pub struct PrettierPluginHandler {
   channel: Channel,
 }
 
-impl Drop for PrettierPluginHandler {
-  fn drop(&mut self) {
-    self.channel.dispose()
-  }
-}
-
 impl PrettierPluginHandler {
   pub fn new() -> Self {
     Self {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use deno_core::futures::future;
 use deno_core::serde_json;
 use dprint_core::configuration::ConfigKeyMap;
 use dprint_core::configuration::GlobalConfiguration;
@@ -69,6 +70,11 @@ impl AsyncPluginHandler for PrettierPluginHandler {
     request: FormatRequest<Self::Configuration>,
     _host: Arc<dyn Host>,
   ) -> BoxFuture<FormatResult> {
+    if request.range.is_some() {
+      // no support for range formatting
+      return Box::pin(future::ready(Ok(None)));
+    }
+
     let channel = self.channel.clone();
     Box::pin(async move { channel.format(request).await })
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
   });
 
   if let Err(err) = result {
-    eprintln!("Shutting down due to error. {}", err);
+    eprintln!("Shutting down due to error: {}", err);
     std::process::exit(1);
   }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,3 +1,4 @@
+use deno_core::v8;
 use deno_core::JsRuntime;
 use deno_core::RuntimeOptions;
 use deno_core::Snapshot;
@@ -5,9 +6,11 @@ use once_cell::sync::Lazy;
 
 pub fn create_js_runtime() -> JsRuntime {
   let snapshot = Snapshot::Static(&*STARTUP_SNAPSHOT);
+  let platform = v8::new_default_platform(1, false).make_shared();
 
   JsRuntime::new(RuntimeOptions {
     startup_snapshot: Some(snapshot),
+    v8_platform: Some(platform),
     ..Default::default()
   })
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,8 @@ use sysinfo::System;
 use sysinfo::SystemExt;
 
 pub fn create_tokio_runtime() -> tokio::runtime::Runtime {
-  // use a single thread for tasks because we need that for deno_core
+  // use a single thread for the communication and for
+  // each of the isolates
   tokio::runtime::Builder::new_current_thread()
     .enable_time()
     .build()


### PR DESCRIPTION
It seems v8 was creating many threads and causing a lot of thread contention. The main fix here is to use:

```rs
let platform = v8::new_default_platform(1, false).make_shared();
```

Where `1` is the number of threads in the worker pool. I found `new_current_thread_platform` or whatever to be extremely slow, but this seemed to be ok.