### PR TITLE
chore: fix showing prettier version in release notes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,8 @@ jobs:
             dprint-plugin-prettier-aarch64-unknown-linux-gnu.zip
             plugin.json
           body: |
+            Prettier ${{ steps.get_prettier_version.outputs.PRETTIER_VERSION }}
+
             ## Install
 
             Dependencies:


### PR DESCRIPTION
https://github.com/dprint/dprint-plugin-prettier/pull/93/files#r1903331386